### PR TITLE
Bug fix to over pass model validation when no documents are provided

### DIFF
--- a/src/Clinic.Core/Models/PatientDocumentsUploadModel.cs
+++ b/src/Clinic.Core/Models/PatientDocumentsUploadModel.cs
@@ -6,5 +6,5 @@ public class PatientDocumentsUploadModel
 {
     public string Patient { get; set; }
 
-    public IFormFileCollection Files { get; set; }
+    public IFormFileCollection? Files { get; set; }
 }

--- a/src/Clinic.Core/Services/PatientRepository.cs
+++ b/src/Clinic.Core/Services/PatientRepository.cs
@@ -54,7 +54,11 @@ public class PatientRepository : IPatientRepository
                 new { patient.Id, patient.FirstName, patient.LastName, patient.BirthDate, patient.NextAppointment });
 
             transaction.Commit();
-            await _documentRepository.CreatePatientDocumentsAsync(files, patient.Id.ToString());
+            
+            if (files != null && files.Any())
+            {
+                await _documentRepository.CreatePatientDocumentsAsync(files, patient.Id.ToString());
+            }
             return result > 0;
         }
         catch (Exception)


### PR DESCRIPTION
- Temporary solution to over pass the bug in creating new `Patient` when no `Documents` are provided.
- In the meantime the creation of documents is related the patient that leads to a tight coupling between `Patient `and `Documents`.
- Once we move to `Visits` and `Appointments` this will be resolved in another way by introducing separate api endpoints.
- For `Documents` it will be there a new endpoint under  `/v1/api/documents` to manage `Documents`.