### PR TITLE
bugfix/Enumerable collection should not return 404

### DIFF
--- a/src/Clinic.Api/Controllers/PatientsController.cs
+++ b/src/Clinic.Api/Controllers/PatientsController.cs
@@ -24,7 +24,7 @@ public class PatientsController : ControllerBase
     {
         var patients = await _patientRepository.GetAllAsync();
         
-        if (!patients.Any()) return NotFound();
+        if (!patients.Any()) return Ok(Enumerable.Empty<PatientResponse>()) ;
 
         return Ok(patients);
     }


### PR DESCRIPTION
@fathi-ch  the HTTP 404 status fits only the not found resources, for collections is advised to return an empty collection.